### PR TITLE
Feat: add invisible lines for judging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,9 +1,15 @@
 package config
 
-//StageHeight Stageの横の長さ
-const StageHeight int = 20
+//InvisibleStageHeight 判定用の描画されないStageの縦の長さ
+const InvisibleStageHeight int = 2
 
-//StageWidth Stageの縦の長さ
+//VisibleStageHeight 描画するStageの縦の長さ
+const VisibleStageHeight int = 20
+
+//StageHeight Stageの縦の長さ
+const StageHeight int = InvisibleStageHeight + VisibleStageHeight
+
+//StageWidth Stageの横の長さ
 const StageWidth int = 10
 
 //Debug デバッグ用ログを表示するかどうか

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -11,9 +11,9 @@ func GetDebugLogs() []string {
 
 //AddDebugLogs デバッグ用のログを追加する
 func AddDebugLogs(log string) {
-	if len(debugLogs) < config.StageHeight {
+	if len(debugLogs) < config.VisibleStageHeight {
 		debugLogs = append(debugLogs, log)
 	} else {
-		debugLogs = append(debugLogs, log)[len(debugLogs)-config.StageHeight+1:]
+		debugLogs = append(debugLogs, log)[len(debugLogs)-config.VisibleStageHeight+1:]
 	}
 }

--- a/store/stage/stage.go
+++ b/store/stage/stage.go
@@ -44,13 +44,3 @@ func (stage *Stage) IsConflictedWith(tetrimino tm.Tetrimino) bool {
 func (stage *Stage) SetMino(mino m.Mino) {
 	stage.Lines[mino.Y].Cells[mino.X].IsFilled = true
 }
-
-//IsGameOver Stageの情報からゲームが終了しているかどうかを返す
-func (stage *Stage) IsGameOver() bool {
-	for _, cell := range stage.Lines[0].Cells {
-		if cell.IsFilled == true {
-			return true
-		}
-	}
-	return false
-}

--- a/store/store.go
+++ b/store/store.go
@@ -80,5 +80,10 @@ func (store *storeType) SetStageCell(x, y int, cell c.Cell) {
 var Store storeType
 
 func init() {
-	Store = storeType{}
+	shapes := []tm.ShapeType{tm.IShape, tm.LShape, tm.JShape, tm.OShape, tm.TShape, tm.SShape, tm.ZShape}
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(shapes), func(i, j int) { shapes[i], shapes[j] = shapes[j], shapes[i] })
+	Store = storeType{
+		tetriminoQueue: shapes,
+	}
 }

--- a/store/store.go
+++ b/store/store.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	a "github.com/tetris-CLI/action"
+	"github.com/tetris-CLI/config"
 	c "github.com/tetris-CLI/store/cell"
 	st "github.com/tetris-CLI/store/stage"
 	tm "github.com/tetris-CLI/store/tetrimino"
@@ -40,7 +41,17 @@ func (store *storeType) GetTetrimino() tm.Tetrimino {
 }
 
 func (store *storeType) SetNextTetrimino() {
-	store.tetrimino = tm.NewTetrimino(store.popTetriminoQueue())
+	tetrimino := tm.NewTetrimino(store.popTetriminoQueue())
+
+	for i := 0; i < config.InvisibleStageHeight; i++ {
+		tetrimino.MoveBy(0, 1)
+		if store.stage.IsConflictedWith(tetrimino) {
+			tetrimino.MoveBy(0, -1)
+			break
+		}
+	}
+
+	store.tetrimino = tetrimino
 	vc.ViewEventManager.Trigger(a.UpdateViewAction)
 }
 

--- a/view/view.go
+++ b/view/view.go
@@ -32,25 +32,26 @@ func UpdateView() {
 }
 
 func drawStage(stage st.Stage) {
-	for y, line := range stage.Lines {
-		termbox.SetCell(0, y+1, '|', termbox.ColorDefault, termbox.ColorDefault)
+	for y := config.InvisibleStageHeight; y < config.StageHeight; y++ {
+		termbox.SetCell(0, y-1, '|', termbox.ColorDefault, termbox.ColorDefault)
+		line := stage.Lines[y]
 
 		for x, cell := range line.Cells {
 			if cell.IsFilled {
-				termbox.SetCell(x+1, y+1, ' ', termbox.ColorDefault, termbox.ColorWhite)
+				termbox.SetCell(x+1, y-1, ' ', termbox.ColorDefault, termbox.ColorWhite)
 			} else {
-				termbox.SetCell(x+1, y+1, ' ', termbox.ColorDefault, termbox.ColorDefault)
+				termbox.SetCell(x+1, y-1, ' ', termbox.ColorDefault, termbox.ColorDefault)
 			}
 		}
 
-		termbox.SetCell(len(line.Cells)+1, y+1, '|', termbox.ColorDefault, termbox.ColorDefault)
+		termbox.SetCell(len(line.Cells)+1, y-1, '|', termbox.ColorDefault, termbox.ColorDefault)
 	}
 
-	termbox.SetCell(0, config.StageHeight+1, '+', termbox.ColorDefault, termbox.ColorDefault)
+	termbox.SetCell(0, config.StageHeight-1, '+', termbox.ColorDefault, termbox.ColorDefault)
 	for i := 0; i < config.StageWidth; i++ {
-		termbox.SetCell(i+1, config.StageHeight+1, '-', termbox.ColorDefault, termbox.ColorDefault)
+		termbox.SetCell(i+1, config.StageHeight-1, '-', termbox.ColorDefault, termbox.ColorDefault)
 	}
-	termbox.SetCell(config.StageWidth+1, config.StageHeight+1, '+', termbox.ColorDefault, termbox.ColorDefault)
+	termbox.SetCell(config.StageWidth+1, config.StageHeight-1, '+', termbox.ColorDefault, termbox.ColorDefault)
 }
 
 var tetriminoColor = map[tm.ShapeType]termbox.Attribute{
@@ -65,7 +66,10 @@ var tetriminoColor = map[tm.ShapeType]termbox.Attribute{
 
 func drawTetrimino(tetrimino tm.Tetrimino) {
 	for _, mino := range tetrimino.Minos {
-		termbox.SetCell(mino.X+1, mino.Y+1, ' ', termbox.ColorDefault, tetriminoColor[tetrimino.Shape])
+		if mino.Y < config.InvisibleStageHeight {
+			continue
+		}
+		termbox.SetCell(mino.X+1, mino.Y-1, ' ', termbox.ColorDefault, tetriminoColor[tetrimino.Shape])
 	}
 }
 
@@ -81,7 +85,7 @@ func drawTetriminoDropPreview(stage st.Stage, tetrimino tm.Tetrimino) {
 	}
 
 	for _, mino := range clone.Minos {
-		termbox.SetCell(mino.X+1, mino.Y+1, '·', tetriminoColor[tetrimino.Shape], termbox.ColorDefault)
+		termbox.SetCell(mino.X+1, mino.Y-1, '·', tetriminoColor[tetrimino.Shape], termbox.ColorDefault)
 	}
 }
 


### PR DESCRIPTION
## Problem

### ゲームオーバー判定の判定がテトリスのルールにしたがっていない

![alt](https://img.atwikiimg.com/www45.atwiki.jp/tetriskakera/attach/19/78/syokiichi01-a.gif)

> テトリスでは次のどちらかの条件が起きると負けになります。
> 	- フィールドのブロックがテトリミノの出現位置と被る
> 	- 21段目にテトリミノを置く

(Ref. https://w.atwiki.jp/tetriskakera/pages/19.html)


### `Tetrimino` 出現時の操作性が悪い

- 現在の仕様では、回転は回転後の `Tetrimino` が `Stage` とConflictしていない際に適用される
- 出現直後に回転すると `Stage` の外に出てしまい、回転が適用されないケースがあった


## Proposal

- `Stage` の上部に `InvisibleStageHeight` 分の `Line` を追加した
